### PR TITLE
Fix Formula.sha1 deprecation warnings

### DIFF
--- a/hadoop-2.5.2.rb
+++ b/hadoop-2.5.2.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class Hadoop252 < Formula
   homepage "http://hadoop.apache.org/"
-  url "http://www.apache.org/dyn/closer.cgi?path=hadoop/common/hadoop-2.5.2/hadoop-2.5.2.tar.gz"
-  sha1 "7571ad3f397e581697de5c8da74207cb1963e2be"
+  url 'http://www.apache.org/dist/hadoop/common/hadoop-2.5.2/hadoop-2.5.2.tar.gz'
+  sha256 '0bdb4850a3825208fc97fd869fb2a4e5b7ad1b49f153d21b75c2da1ad5016b43'
 
   def install
     rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]

--- a/hadoop-2.6.0-with-jets3t-0.7.4.rb
+++ b/hadoop-2.6.0-with-jets3t-0.7.4.rb
@@ -4,7 +4,7 @@ class Hadoop260WithJets3t074 < Formula
   homepage "http://hadoop.apache.org/"
   # we downgraded the jets3t JAR to 0.7.4 so that s3 access actually works.
   url 'http://s3.amazonaws.com/korrelate-public-repo/hadoop/hadoop/hadoop-2.6.0-downgrade-to-jets3t-0.7.4.tar.gz'
-  sha1 "a6446ceea8ddb49936c7193cf5e38a133e8a5855"
+  sha256 'b9608d2f490ed45c5d776b6d75dd1cff79bf21461fbe52fce273ead349c8a1dd'
 
   def install
     rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]

--- a/hadoop-2.6.0.rb
+++ b/hadoop-2.6.0.rb
@@ -3,7 +3,7 @@ require "formula"
 class Hadoop260 < Formula
   homepage "http://hadoop.apache.org/"
   url 'http://s3.amazonaws.com/korrelate-public-repo/hadoop/hadoop/hadoop-2.6.0.tar.gz'
-  sha1 '5b5fb72445d2e964acaa62c60307168c009d57c5'
+  sha256 '7a2ef6e7f468afcae95d0f7214816033c7e5c7982454061ccb117896d58d279f'
 
   # this patch is needed for hadoop 2.6.0 and following to work with s3 URLs. It adds
   # the tools directory to the classpath which used to be a part of the classpath by default.

--- a/hadoop-2.7.1.rb
+++ b/hadoop-2.7.1.rb
@@ -3,7 +3,7 @@ require "formula"
 class Hadoop271 < Formula
   homepage "http://hadoop.apache.org/"
   url 'http://s3.amazonaws.com/korrelate-public-repo/hadoop/hadoop/hadoop-2.7.1.tar.gz'
-  sha1 'bb0f3781a90e279f8d1963674e7a26a84b9bd8a3'
+  sha256 'df4cd44c4a788fe21aaa3e64d7b73c4ace590a00a767de6b9a5bcc743dfb85a5'
 
   # this patch is needed for hadoop 2.6.0 and following to work with s3 URLs. It adds
   # the tools directory to the classpath which used to be a part of the classpath by default.

--- a/hbase-0.98.13-hadoop-2.6.0.rb
+++ b/hbase-0.98.13-hadoop-2.6.0.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Hbase09813Hadoop260 < Formula
   homepage 'http://hbase.apache.org'
   url 'http://s3.amazonaws.com/korrelate-public-repo/hadoop/hbase/hbase-0.98.13-hadoop-2.6.0-SNAPSHOT-bin.tar.gz'
-  sha1 'a0139f9d4026fd20171d7baba5ab03d023eb8338'
+  sha256 '8907f2b0ef5153f9fb29ee257102dc3c91f1eafaefeeee0384b484516b7358b2'
 
   depends_on 'hadoop-2.5.2'
 

--- a/hbase-0.98.8.rb
+++ b/hbase-0.98.8.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Hbase0988 < Formula
   homepage 'http://hbase.apache.org'
   url 'http://archive.apache.org/dist/hbase/hbase-0.98.8/hbase-0.98.8-hadoop2-bin.tar.gz'
-  sha1 'a1b5d19a52976f2f42f21dd36bd040d081f3d491'
+  sha256 '665f55eca3ca54b3abcbe8d6fe3b918d64e387ec5f5c61ab79506cc42f567d5b'
 
   depends_on 'hadoop-2.5.2'
 

--- a/hbase-1.1.2.rb
+++ b/hbase-1.1.2.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Hbase112 < Formula
   homepage 'http://hbase.apache.org'
   url 'http://s3.amazonaws.com/korrelate-public-repo/hadoop/hbase/hbase-1.1.2.tar.gz'
-  sha1 'dc62a7bb102cb5c7096e74fe882699a2dddea8a4'
+  sha256 '8ca5bf0203cef86b4a0acbba89afcd5977488ebc73eec097e93c592b16f8bede'
 
   depends_on 'hadoop-2.5.2'
 
@@ -32,6 +32,7 @@ class Hbase112 < Formula
 
   resource "phoenix_client" do
     url "http://korrelate-public-repo.s3.amazonaws.com/hadoop/phoenix/phoenix-4.4.0-HBase-1.1-client.jar"
+    sha256 '30a8bc444542cdbfc5eb7b228e3b23b7a3220991347f31daeb6d628a8e716d42'
   end
 
 end


### PR DESCRIPTION
I'm not entirely sure how to test this without cloning locally and updating O2O/Brewfile to tap the local path instead, so here you go:

1. Clone the repo: `git clone git@github.com:korrelate/homebrew-tap /tmp/homebrew-tap`
1. Uninstall the kegs we want to test and cleanup the cache:

  ```
  brew uninstall hadoop-2.5.2
  brew uninstall hadoop-2.6.0-with-jets3t-0.7.4
  brew uninstall hadoop-2.6.0
  brew uninstall hadoop-2.7.1
  brew uninstall hbase-0.98.13-hadoop-2.6.0
  brew uninstall hbase-0.98.8
  brew uninstall hbase-1.1.2
  brew cleanup -s
  ```

1. In `.../O2O/Brewfile`, replace the line `brew tap korrelate/homebrew-tap` with `brew tap korrelate/homebrew-tap /tmp/homebrew-tap` and save.
1. Run Brewfile: `.../O2O/Brewfile`
1. Revert your changes to the Brewfile

You should not see any of the Formula.sha1 deprecation warnings in the output.